### PR TITLE
[aime_1984_p1] fix proof (was broken in mathlib update)

### DIFF
--- a/lean/src/test/aime_1984_p1.lean
+++ b/lean/src/test/aime_1984_p1.lean
@@ -14,12 +14,11 @@ open_locale big_operators
 lemma sum_pairs (n : ℕ) (f : ℕ → ℚ) :
   ∑ k in (finset.range (2 * n)), f k = ∑ k in (finset.range n), (f (2 * k) + f (2 * k + 1)) :=
 begin
-  -- induction n with pn hpn,
-  -- { simp only [finset.sum_empty, finset.range_zero, mul_zero] },
-  -- { have hs: (2 * pn.succ) = (2 * pn).succ.succ := rfl,
-  --   rw [finset.sum_range_succ, ←hpn, hs, finset.sum_range_succ,
-  --       finset.sum_range_succ, ←add_assoc, add_comm (f (2 * pn).succ) (f (2 * pn))] },
-  sorry,
+  induction n with pn hpn,
+  { simp only [finset.sum_empty, finset.range_zero, mul_zero] },
+  { have hs: (2 * pn.succ) = (2 * pn).succ.succ := rfl,
+    rw [finset.sum_range_succ, ←hpn, hs, finset.sum_range_succ, finset.sum_range_succ],
+    ring },
 end
 
 theorem aime_1984_p1


### PR DESCRIPTION
Finishes the proof using the `ring` tactic, which should be more
robust than than using the manual `add_assoc` and `add_comm`
rewrites that we were using before.

(Another way to fix the proof would be to just remove the final
`add_comm` rewrite.)