### PR TITLE
prove Induction sumkexp3eqsumksq

### DIFF
--- a/lean/src/test.lean
+++ b/lean/src/test.lean
@@ -527,11 +527,24 @@ begin
   sorry
 end
 
-theorem induction_sumkexp3eqsumksqsq
+theorem induction_sumkexp3eqsumksq
   (n : ℕ) :
-  ∑ k in finset.range n, k^3 = (∑ k in finset.range n, k^2)^2 :=
+  ∑ k in finset.range n, k^3 = (∑ k in finset.range n, k)^2 :=
 begin
-  sorry
+  symmetry,
+  induction n with j IH,
+  {
+    refl,
+  },
+  {
+    calc (∑ (k : ℕ) in finset.range j.succ, k)^2 = ((∑ (k : ℕ) in finset.range j, k) + j )^2 : by rw finset.sum_range_succ  -- rewrite summation
+   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (∑ (k : ℕ) in finset.range j, k) * j + j^2 : by rw add_sq _ _ -- (a + b)^2
+   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (j * (j-1)/2) * j + j^2 : by rw finset.sum_range_id j -- sum = j*(j-1)/2
+   ... = (∑ (k : ℕ) in finset.range j, k^3) + 2 * (j * (j-1)/2) * j + j^2 : by rw IH
+   ... = (∑ (k : ℕ) in finset.range j, k^3) + j^2 * (j-1) + j^2 : by ring_nf -- 2 * ( ... )/2 = ( ... )
+   ... = (∑ (k : ℕ) in finset.range j, k^3) + j^3 : by ring_nf -- (j +1)^2 (j+1) = (j+1)^3
+   ... = (∑ (k : ℕ) in finset.range j.succ, k^3) : by rw ← finset.sum_range_succ, -- by the definition of summation
+  }
 end
 
 theorem numbertheory_fxeq4powxp6powxp9powx_f2powmdvdf2pown

--- a/lean/src/test.lean
+++ b/lean/src/test.lean
@@ -537,13 +537,14 @@ begin
     refl,
   },
   {
-    calc (∑ (k : ℕ) in finset.range j.succ, k)^2 = ((∑ (k : ℕ) in finset.range j, k) + j )^2 : by rw finset.sum_range_succ  -- rewrite summation
-   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (∑ (k : ℕ) in finset.range j, k) * j + j^2 : by rw add_sq _ _ -- (a + b)^2
-   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (j * (j-1)/2) * j + j^2 : by rw finset.sum_range_id j -- sum = j*(j-1)/2
-   ... = (∑ (k : ℕ) in finset.range j, k^3) + 2 * (j * (j-1)/2) * j + j^2 : by rw IH
-   ... = (∑ (k : ℕ) in finset.range j, k^3) + j^2 * (j-1) + j^2 : by ring_nf -- 2 * ( ... )/2 = ( ... )
-   ... = (∑ (k : ℕ) in finset.range j, k^3) + j^3 : by ring_nf -- (j +1)^2 (j+1) = (j+1)^3
-   ... = (∑ (k : ℕ) in finset.range j.succ, k^3) : by rw ← finset.sum_range_succ, -- by the definition of summation
+    calc (∑ (k : ℕ) in finset.range j.succ, k)^2 = ((∑ (k : ℕ) in finset.range j, k) + j )^2 : by rw finset.sum_range_succ
+   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (∑ (k : ℕ) in finset.range j, k) * j + j^2 : by rw add_sq _ _ 
+   ... = (∑ (k : ℕ) in finset.range j, k)^2 +  (∑ (k : ℕ) in finset.range j, k) * 2 * j + j^2 : by ring
+   ... = (∑ (k : ℕ) in finset.range j, k)^2 + (j * (j-1)) * j + j^2 : by rw finset.sum_range_id_mul_two j
+   ... = (∑ (k : ℕ) in finset.range j, k^3) + (j * (j-1)) * j + j^2 : by rw IH
+   ... = (∑ (k : ℕ) in finset.range j, k^3) + j^2 * (j-1) + j^2 : by ring_nf
+   ... = (∑ (k : ℕ) in finset.range j, k^3) + j^3 : by cases j ; [norm_num, ring_nf]
+   ... = (∑ (k : ℕ) in finset.range j.succ, k^3) : by rw ← finset.sum_range_succ,
   }
 end
 

--- a/lean/src/test.lean
+++ b/lean/src/test.lean
@@ -311,7 +311,7 @@ theorem mathd_algebra_137
   x = 575 :=
 begin
   have h₁ : ↑x = (575:ℝ), linarith,
-  assumption_mod_cast, 
+  assumption_mod_cast,
 end
 
 theorem imo_1997_p5
@@ -537,8 +537,8 @@ begin
     refl,
   },
   {
-    calc (∑ (k : ℕ) in finset.range j.succ, k)^2 = ((∑ (k : ℕ) in finset.range j, k) + j )^2 : by rw finset.sum_range_succ
-   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (∑ (k : ℕ) in finset.range j, k) * j + j^2 : by rw add_sq _ _ 
+    calc (∑ (k : ℕ) in finset.range j.succ, k)^2 = ((∑ (k : ℕ) in finset.range j, k) + j)^2 : by rw finset.sum_range_succ
+   ... = (∑ (k : ℕ) in finset.range j, k)^2 + 2 * (∑ (k : ℕ) in finset.range j, k) * j + j^2 : by rw add_sq _ _
    ... = (∑ (k : ℕ) in finset.range j, k)^2 +  (∑ (k : ℕ) in finset.range j, k) * 2 * j + j^2 : by ring
    ... = (∑ (k : ℕ) in finset.range j, k)^2 + (j * (j-1)) * j + j^2 : by rw finset.sum_range_id_mul_two j
    ... = (∑ (k : ℕ) in finset.range j, k^3) + (j * (j-1)) * j + j^2 : by rw IH


### PR DESCRIPTION
I also corrected the theorem as it was incorrect, the original statement was:

  ∑ k in finset.range n, k^3 = (∑ k in finset.range n, k^2)^2

Which couldn't be true, for if it was, then for k = 3, we would have the LHS being equal to:

0 + 1^3 + 2^3 = 9

but then on the other hand (right to be exact), we would have

(0^2 + 1^2 + 2^2)^2 = 5^2 = 25.

So instead I modified the statement to be:

  ∑ k in finset.range n, k^3 = (∑ k in finset.range n, k)^2

and proved that instead, I also modified the name of the statement to match as well.

Thank you to Alex J Best for helping me understand `ring_nf` in more detail.