### PR TITLE
Fix formalization of mathd_algebra_13

### DIFF
--- a/lean/src/valid.lean
+++ b/lean/src/valid.lean
@@ -122,7 +122,7 @@ end
 
 theorem mathd_algebra_13
   (a b :ℝ)
-  (h₀ : ∀ x, 4 * x / (x^2 - 8 * x + 15) = a / (x - 3) + b / (x - 5)) :
+  (h₀ : ∀ x, (x - 3 ≠ 0 ∧ x - 5 ≠ 0) → 4 * x / (x^2 - 8 * x + 15) = a / (x - 3) + b / (x - 5)) :
   a = -6 ∧ b = 10 :=
 begin
   sorry


### PR DESCRIPTION
Fixes an oversight in the formalization `mathd_algebra_13`, where denominators were required to be non-zero (in Lean division by `0` is defined and outputs `0`).